### PR TITLE
Fix get requests and variable app name for heroku environments

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -41,7 +41,6 @@ exports.login = async (req, res) => {
                 let firstName = user.firstName;
                 let lastName = user.lastName;
                 let userName = user.userName;
-                console.log(refreshToken);
                 res.cookie('refreshToken', refreshToken, {httpOnly: true});
                 return res.status(200).json({ accessToken, id, firstName, lastName, userName});
             } else {

--- a/backend/models/user.model.js
+++ b/backend/models/user.model.js
@@ -17,7 +17,6 @@ userSchema.methods = {
     createAccessToken: async function() {
         try {
             let {_id, userName} = this;
-            console.log(_id + ' ' + userName);
             let accessToken = jwt.sign(
                 {user: {_id, userName}},
                 ACCESS_TOKEN_SECRET, {expiresIn: ACCESS_TOKEN_LIFE}

--- a/backend/routes/router.js
+++ b/backend/routes/router.js
@@ -10,7 +10,7 @@ router.post('/auth/refresh', AuthController.refresh);
 
 router.delete('/auth/logout', AuthController.logout);
 
-router.post('/protected', Middleware.verify, (req, res) => {
+router.get('/protected', Middleware.verify, (req, res) => {
     res.setHeader('content-type', 'application/json; charset=utf-8')
     return res.status(200).json({userName: req.user.userName,
                                  id: req.user.id});

--- a/backend/routes/router.js
+++ b/backend/routes/router.js
@@ -6,7 +6,7 @@ router.post('/auth/signup', AuthController.signup);
 
 router.post('/auth/login', AuthController.login);
 
-router.post('/auth/refresh', AuthController.refresh);
+router.get('/auth/refresh', AuthController.refresh);
 
 router.delete('/auth/logout', AuthController.logout);
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -24,6 +24,8 @@ mongoose.connect(process.env.MONGODB_URI, {
 }).then(() => console.log("Connected to database."))
 .catch((e) => console.error(e));
 
+app.use('/api', api);
+
 // For Heroku deployment
 // Server static assets if in production
 if (process.env.NODE_ENV === 'production') 
@@ -44,12 +46,6 @@ app.use(function(req, res, next) {
   res.header('Access-Control-Allow-Headers', 'X-Requested-With, X-HTTP-Method-Override, Content-Type, Accept');
   next();
 })
-
-app.get("/", (req, res) => {
-  return res.status(200).send('ok');
-})
-
-app.use('/api', api);
 
 app.listen(PORT, () =>
 {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,10 +1,9 @@
 import axios from "axios"
 axios.defaults.withCredentials = true;
 
-const app_name = 'cop4331-group11-large'
 var url;
 if (process.env.NODE_ENV === 'production') {
-    url = 'https://' + app_name +  '.herokuapp.com/api';
+    url = 'https://' + process.env.APP_NAME +  '.herokuapp.com/api';
 }
 else {        
     url = 'http://localhost:5000/api';

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -5,7 +5,7 @@ const app_name = 'cop4331-group11-large';
 //const app_name = 'group11largeproject-dev';
 var url;
 if (process.env.NODE_ENV === 'production') {
-    url = 'https://' + app_name +  '.herokuapp.com/api';
+    url = 'https://' + process.env.REACT_APP_NAME +  '.herokuapp.com/api';
 }
 else {        
     url = 'http://localhost:5000/api';

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -3,6 +3,7 @@ axios.defaults.withCredentials = true;
 
 // const app_name = 'cop4331-group11-large';
 const app_name = 'group11largeproject-dev';
+var url;
 if (process.env.NODE_ENV === 'production') {
     url = 'https://' + app_name +  '.herokuapp.com/api';
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -37,7 +37,7 @@ axios.interceptors.response.use(
             !originalRequest._retry
         ) {
             originalRequest._retry = true;
-            return axios.post(`${url}/auth/refresh`)
+            return axios.get(`${url}/auth/refresh`)
             .then((res) => {
                 if (res.status === 200) {
                     let accessToken = JSON.stringify(res.data.accessToken);
@@ -60,7 +60,7 @@ const api = {
         return axios.post(`${url}/auth/login`, body);
     },
     refresh: () => {
-        return axios.post(`${url}/auth/refresh`);
+        return axios.get(`${url}/auth/refresh`);
     },
     logout: (body) => {
         return axios.delete(`${url}/auth/logout`, {data: body});

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,8 +1,8 @@
 import axios from "axios"
 axios.defaults.withCredentials = true;
 
-// const app_name = 'cop4331-group11-large';
-const app_name = 'group11largeproject-dev';
+const app_name = 'cop4331-group11-large';
+//const app_name = 'group11largeproject-dev';
 var url;
 if (process.env.NODE_ENV === 'production') {
     url = 'https://' + app_name +  '.herokuapp.com/api';

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,8 +1,6 @@
 import axios from "axios"
 axios.defaults.withCredentials = true;
 
-const app_name = 'cop4331-group11-large';
-//const app_name = 'group11largeproject-dev';
 var url;
 if (process.env.NODE_ENV === 'production') {
     url = 'https://' + process.env.REACT_APP_NAME +  '.herokuapp.com/api';
@@ -42,7 +40,6 @@ axios.interceptors.response.use(
                 if (res.status === 200) {
                     let accessToken = JSON.stringify(res.data.accessToken);
                     localStorage.setItem('accessToken', accessToken);
-                    console.log(accessToken);
                     console.log('Refreshed access token.')
                     return axios(originalRequest);
                 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -62,10 +62,10 @@ const api = {
         return axios.post(`${url}/auth/refresh`);
     },
     logout: (body) => {
-        return axios.delete(`${url}/auth/logout`, body);
+        return axios.delete(`${url}/auth/logout`, {data: body});
     },
     protected: () => {
-        return axios.post(`${url}/protected`);
+        return axios.get(`${url}/protected`);
     }
 };
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,9 +1,10 @@
 import axios from "axios"
 axios.defaults.withCredentials = true;
 
-var url;
+// const app_name = 'cop4331-group11-large';
+const app_name = 'group11largeproject-dev';
 if (process.env.NODE_ENV === 'production') {
-    url = 'https://' + process.env.APP_NAME +  '.herokuapp.com/api';
+    url = 'https://' + app_name +  '.herokuapp.com/api';
 }
 else {        
     url = 'http://localhost:5000/api';

--- a/frontend/src/components/LoggedInName.js
+++ b/frontend/src/components/LoggedInName.js
@@ -10,16 +10,14 @@ function LoggedInName()
     var firstName = ud.firstName;
     var lastName = ud.lastName;
 
-    console.log(_ud);
-    console.log(localStorage.getItem('accessToken'));
     const doLogout = event => 
     {
 	    event.preventDefault();
-
-        // call logout api here
+        let _userData = localStorage.getItem('user_data');
+        let userData = JSON.parse(_userData);
+        api.logout({userId: userData.id});
         localStorage.removeItem('user_data');
         localStorage.removeItem('accessToken')
-        // delete refresh cookie here
         window.location.href = '/';
 
     };    


### PR DESCRIPTION
Fixed an issue with the order of express configurations for get requests.

Changed api.js to allow variable app names for both dev and prod environments.

Also removed a bunch of console.logs that were used for debugging so we don't forget to remove them later on.